### PR TITLE
Fix check treasures action

### DIFF
--- a/lib/display.py
+++ b/lib/display.py
@@ -99,7 +99,7 @@ def recieve_treasures(data):
 def check_treasures(data):
     temp = "{.TREASURE}[TREASURE]{.ENDC}".format(
             printer.PColors, printer.PColors)
-    for cat in [cat for cat in data["cats"] if cat["given_treasure"]]:
+    for cat in [cat for cat in data["cats"].itervalues() if cat["given_treasure"]]:
         printer.p(temp, "You have a treasure from {0}! {1}!!!".format(
                 cat["name"], cat["treasure"]))
 


### PR DESCRIPTION
`check_treasures` iterated over the keys of `data["cats"]` but assumed the values were objects. This caused a `string indices must be integers` error. A quick `itervalues()` should fix this right up.

![yup](https://media.giphy.com/media/pIIbKh5RO8TSg/giphy.gif)
